### PR TITLE
Enter event park preferences w/o backend logic

### DIFF
--- a/client/src/components/MapsInput.tsx
+++ b/client/src/components/MapsInput.tsx
@@ -10,10 +10,10 @@ import { Button } from "./ui/button";
 interface MapsInputProps {
   location: string;
   setLocation: (location: string) => void;
-  useMap: boolean;
+  showMap: boolean;
 }
 const libraries: Libraries = ["places"];
-const MapsInput = ({ location, setLocation, useMap }: MapsInputProps) => {
+const MapsInput = ({ location, setLocation, showMap }: MapsInputProps) => {
   const [coords, setCoords] = useState<google.maps.LatLngLiteral>({
     lat: 0,
     lng: 0,
@@ -48,7 +48,7 @@ const MapsInput = ({ location, setLocation, useMap }: MapsInputProps) => {
     <div className="w-1/1 flex justify-center items-center flex-col">
       {isLoaded && (
         <>
-          {useMap && (
+          {showMap && (
             <GoogleMap
               mapContainerStyle={{
                 width: "100%",

--- a/client/src/components/MapsInput.tsx
+++ b/client/src/components/MapsInput.tsx
@@ -10,9 +10,10 @@ import { Button } from "./ui/button";
 interface MapsInputProps {
   location: string;
   setLocation: (location: string) => void;
+  useMap: boolean;
 }
 const libraries: Libraries = ["places"];
-const MapsInput = ({ location, setLocation }: MapsInputProps) => {
+const MapsInput = ({ location, setLocation, useMap }: MapsInputProps) => {
   const [coords, setCoords] = useState<google.maps.LatLngLiteral>({
     lat: 0,
     lng: 0,
@@ -47,15 +48,17 @@ const MapsInput = ({ location, setLocation }: MapsInputProps) => {
     <div className="w-1/1 flex justify-center items-center flex-col">
       {isLoaded && (
         <>
-          <GoogleMap
-            mapContainerStyle={{
-              width: "100%",
-              height: "250px",
-              maxWidth: "600px",
-            }}
-            center={coords}
-            zoom={15}
-          ></GoogleMap>
+          {useMap && (
+            <GoogleMap
+              mapContainerStyle={{
+                width: "100%",
+                height: "250px",
+                maxWidth: "600px",
+              }}
+              center={coords}
+              zoom={15}
+            ></GoogleMap>
+          )}
           <div className="w-1/1 m-2 flex">
             <div className="w-1/1">
               <StandaloneSearchBox
@@ -64,7 +67,7 @@ const MapsInput = ({ location, setLocation }: MapsInputProps) => {
               >
                 <Input
                   type="text"
-                  placeholder="Enter your address..."
+                  placeholder="Enter address..."
                   className="w-1/1"
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
@@ -72,6 +75,7 @@ const MapsInput = ({ location, setLocation }: MapsInputProps) => {
               </StandaloneSearchBox>
             </div>
             <Button
+              className="mr-0"
               variant="secondary"
               onClick={(e) => {
                 e.preventDefault();

--- a/client/src/components/events-components/CustomEventFilters.tsx
+++ b/client/src/components/events-components/CustomEventFilters.tsx
@@ -68,7 +68,7 @@ const CustomEventFilters = ({
           })}
         </SelectContent>
       </Select>
-      <MapsInput location={location} setLocation={setLocation} useMap={true} />
+      <MapsInput location={location} setLocation={setLocation} showMap={true} />
       <Button type="submit" className="w-1/1">
         Submit
       </Button>

--- a/client/src/components/events-components/CustomEventFilters.tsx
+++ b/client/src/components/events-components/CustomEventFilters.tsx
@@ -68,7 +68,7 @@ const CustomEventFilters = ({
           })}
         </SelectContent>
       </Select>
-      <MapsInput location={location} setLocation={setLocation} />
+      <MapsInput location={location} setLocation={setLocation} useMap={true} />
       <Button type="submit" className="w-1/1">
         Submit
       </Button>

--- a/client/src/components/events-components/EventComments.tsx
+++ b/client/src/components/events-components/EventComments.tsx
@@ -1,0 +1,52 @@
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import CommentBox from "./CommentBox";
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { createComment } from "@/utils/eventService";
+import type { Comment } from "@/utils/interfaces";
+
+interface EventCommentsProps {
+  eventId: number;
+  setCommentList: (comments: Comment[]) => void;
+  commentList: Comment[];
+}
+
+const EventComments = ({
+  eventId,
+  commentList,
+  setCommentList,
+}: EventCommentsProps) => {
+  const [comment, setComment] = useState("");
+  const handleCommentSubmission = async (e: FormEvent) => {
+    e.preventDefault();
+    const createdComment = await createComment(eventId, comment);
+    setCommentList([createdComment, ...commentList]);
+    setComment("");
+  };
+
+  return (
+    <>
+      <form className="flex" onSubmit={handleCommentSubmission}>
+        <Input
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          type="text"
+          placeholder="Enter a comment"
+          className=""
+        />
+        <Button type="submit">Comment</Button>
+      </form>
+
+      <div className="w-1/1 h-1/1 flex flex-col">
+        {commentList.map((commentInstance) => {
+          return (
+            <CommentBox key={commentInstance.id} comment={commentInstance} />
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+export default EventComments;

--- a/client/src/components/events-components/EventModalContent.tsx
+++ b/client/src/components/events-components/EventModalContent.tsx
@@ -1,22 +1,33 @@
 import type { DisplayEvent, Comment } from "@/utils/interfaces";
-import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { useState, type FormEvent } from "react";
-import { createComment } from "@/utils/eventService";
-import CommentBox from "./CommentBox";
+import { useState } from "react";
+import EventComments from "./EventComments";
+import EventParkPreferences from "./EventParkPreferences";
 
 interface EventModalContentType {
   event: DisplayEvent;
 }
 
+const viewTypes = {
+  comments: 0,
+  enterPreferences: 1,
+  viewRecommendedParks: 2,
+};
+
 const EventModalContent = ({ event }: EventModalContentType) => {
-  const [comment, setComment] = useState("");
   const [commentList, setCommentList] = useState<Comment[]>(event.comments);
-  const handleCommentSubmission = async (e: FormEvent) => {
-    e.preventDefault();
-    const createdComment = await createComment(event.id, comment);
-    setCommentList([createdComment, ...commentList]);
-    setComment("");
+  const [preferenceList, setPreferenceList] = useState<string[]>([]);
+  const [recommendationList, setRecommendationList] = useState<string[]>([]);
+  const [viewType, setViewType] = useState<number>(viewTypes.comments);
+  const handleCommentToggle = () => {
+    setViewType(viewTypes.comments);
+  };
+
+  const handlePreferenceViewToggle = () => {
+    setViewType(viewTypes.enterPreferences);
+  };
+  const handleRecommendParksToggle = () => {
+    setViewType(viewTypes.viewRecommendedParks);
   };
   return (
     <div className="flex flex-col md:flex-row w-9/10 h-9/10 grow-1 overflow-auto">
@@ -35,23 +46,46 @@ const EventModalContent = ({ event }: EventModalContentType) => {
         </div>
       </div>
       <div className="grow-1 mt-2 flex flex-col">
-        <form className="flex" onSubmit={handleCommentSubmission}>
-          <Input
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            type="text"
-            placeholder="Enter a comment"
-            className=""
-          />
-          <Button type="submit">Comment</Button>
-        </form>
-        <div className="w-1/1 h-1/1 flex flex-col">
-          {commentList.map((commentInstance) => {
-            return (
-              <CommentBox key={commentInstance.id} comment={commentInstance} />
-            );
-          })}
+        <div className="w-1/1 flex flex-row justify-around my-2 flex-wrap">
+          <Button
+            onClick={handleCommentToggle}
+            className="m-1"
+            disabled={viewType === viewTypes.comments}
+          >
+            Comments
+          </Button>
+          <Button
+            onClick={handlePreferenceViewToggle}
+            className="m-1"
+            disabled={viewType === viewTypes.enterPreferences}
+          >
+            Park Preferences
+          </Button>
+          <Button
+            onClick={handleRecommendParksToggle}
+            className="m-1"
+            disabled={viewType === viewTypes.viewRecommendedParks}
+          >
+            Park Recommendations
+          </Button>
         </div>
+        {viewType === viewTypes.comments && (
+          <EventComments
+            eventId={event.id}
+            commentList={commentList}
+            setCommentList={setCommentList}
+          />
+        )}
+        {viewType === viewTypes.enterPreferences && (
+          <EventParkPreferences
+            eventId={event.id}
+            preferenceList={preferenceList}
+            setPreferenceList={setPreferenceList}
+          />
+        )}
+        {viewType === viewTypes.viewRecommendedParks && (
+          <div>These parks are recommended</div>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/events-components/EventModalContent.tsx
+++ b/client/src/components/events-components/EventModalContent.tsx
@@ -17,7 +17,6 @@ const viewTypes = {
 const EventModalContent = ({ event }: EventModalContentType) => {
   const [commentList, setCommentList] = useState<Comment[]>(event.comments);
   const [preferenceList, setPreferenceList] = useState<string[]>([]);
-  const [recommendationList, setRecommendationList] = useState<string[]>([]);
   const [viewType, setViewType] = useState<number>(viewTypes.comments);
   const handleCommentToggle = () => {
     setViewType(viewTypes.comments);

--- a/client/src/components/events-components/EventModify.tsx
+++ b/client/src/components/events-components/EventModify.tsx
@@ -113,7 +113,7 @@ const EventModify = ({
           setLocation={(location) => {
             setEventLocation(location);
           }}
-          useMap={true}
+          showMap={true}
         />
         <Calendar
           mode="single"

--- a/client/src/components/events-components/EventModify.tsx
+++ b/client/src/components/events-components/EventModify.tsx
@@ -113,6 +113,7 @@ const EventModify = ({
           setLocation={(location) => {
             setEventLocation(location);
           }}
+          useMap={true}
         />
         <Calendar
           mode="single"

--- a/client/src/components/events-components/EventParkPreferences.tsx
+++ b/client/src/components/events-components/EventParkPreferences.tsx
@@ -8,7 +8,6 @@ interface EventParkPreferencesProps {
   setPreferenceList: (preferences: string[]) => void;
 }
 const EventParkPreferences = ({
-  eventId,
   preferenceList,
   setPreferenceList,
 }: EventParkPreferencesProps) => {
@@ -22,7 +21,7 @@ const EventParkPreferences = ({
         <MapsInput
           location={newPreference}
           setLocation={setNewPreference}
-          useMap={false}
+          showMap={false}
         />
         <Button className="w-1/1 mx-0" onClick={handleNewParkPreference}>
           Submit

--- a/client/src/components/events-components/EventParkPreferences.tsx
+++ b/client/src/components/events-components/EventParkPreferences.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Button } from "../ui/button";
+import MapsInput from "../MapsInput";
+
+interface EventParkPreferencesProps {
+  eventId: number;
+  preferenceList: string[];
+  setPreferenceList: (preferences: string[]) => void;
+}
+const EventParkPreferences = ({
+  eventId,
+  preferenceList,
+  setPreferenceList,
+}: EventParkPreferencesProps) => {
+  const [newPreference, setNewPreference] = useState("");
+  const handleNewParkPreference = () => {
+    setPreferenceList([newPreference, ...preferenceList]);
+  };
+  return (
+    <>
+      <div className="flex flex-row flex-wrap">
+        <MapsInput
+          location={newPreference}
+          setLocation={setNewPreference}
+          useMap={false}
+        />
+        <Button className="w-1/1 mx-0" onClick={handleNewParkPreference}>
+          Submit
+        </Button>
+      </div>
+      {preferenceList.map((preference) => {
+        return <h1>{preference}</h1>;
+      })}
+    </>
+  );
+};
+
+export default EventParkPreferences;

--- a/client/src/components/profile-components/ProfileForm.tsx
+++ b/client/src/components/profile-components/ProfileForm.tsx
@@ -36,7 +36,7 @@ const ProfileForm = ({
         setLocation={(location) =>
           setProfile({ ...profile, location: location })
         }
-        useMap={true}
+        showMap={true}
       />
 
       <label className="self-start ml-1">Profile Picture URL (Optional):</label>

--- a/client/src/components/profile-components/ProfileForm.tsx
+++ b/client/src/components/profile-components/ProfileForm.tsx
@@ -36,6 +36,7 @@ const ProfileForm = ({
         setLocation={(location) =>
           setProfile({ ...profile, location: location })
         }
+        useMap={true}
       />
 
       <label className="self-start ml-1">Profile Picture URL (Optional):</label>

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        disabled: "bg-gray disabled",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
**Description**
This PR works towards my TC2 because it lets users enter their park preferences. Right now it only allows you to enter an address and that address displays.

In future PRs, the backend logic will be implemented for adding park preferences, and the user will be able to upvote parks.

**Milestones**
This works towards my TC2.

**Resources**
N/A

**Test Plan**
<div>
    <a href="https://www.loom.com/share/04c07b3ce3754ed3833e44d00fa4ac79">
      <p>Loom Message - 15 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/04c07b3ce3754ed3833e44d00fa4ac79">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/04c07b3ce3754ed3833e44d00fa4ac79-064d4a9b1b8aaba9-full-play.gif">
    </a>
  </div>
