### PR TITLE
Outlier detection

### DIFF
--- a/server/meetingPoints/outliers.js
+++ b/server/meetingPoints/outliers.js
@@ -1,0 +1,37 @@
+const { performHaversine } = require("../recommendations/locationUtils");
+
+const filterOutliers = (users, organizer, multiplier = 2) => {
+  if (users.length < 3) {
+    return { keptUsers: users, droppedUsers: [] };
+  }
+  const distances = users.map((user) => {
+    return performHaversine(
+      user.latitude,
+      user.longitude,
+      organizer.latitude,
+      organizer.longitude
+    );
+  });
+  const median = findMedian(distances);
+  const keptUsers = users.filter((user, index) => {
+    if (distances[index] <= median * multiplier || distances[index] <= 50) {
+      return user;
+    }
+  });
+  const droppedUsers = users.filter((user, index) => {
+    if (distances[index] > median * multiplier) {
+      return user;
+    }
+  });
+  return { keptUsers, droppedUsers };
+};
+
+const findMedian = (distances) => {
+  const sortedDistances = distances.toSorted((a, b) => a - b);
+  const midIndex = Math.floor(distances.length / 2);
+  return sortedDistances.length % 2
+    ? sortedDistances[midIndex]
+    : (sortedDistances[midIndex] + sortedDistances[midIndex]) / 2;
+};
+
+module.exports = { filterOutliers };


### PR DESCRIPTION
**Description**
This PR creates a system for detecting outliers when selecting the best park. For simplicity purposes, it sets the base location to the creators location. It then calculates the median distance from each user to the base location and filters out any user who is not within 50 miles or within the median * a multiplier. This prevents users who are located a long distance away from having a large affect on the park recommended. Further change considerations, it may be better to base the base location on the park originally set for the event to prevent biased recommendations near where the creator lives. Additionally, users get recommended events based on where the original park is set, so users will likely live closer to that.

In further PRs, changes to the base location may be made.
**Milestones**
This works towards technical challenge #2, which involves recommending parks.

**Resources**
N/A

**Test Plan**
The image shows a response that does not consider a user who was RSVP'd for the event because he was an outlier and his location was set to Texas.
<img width="1920" height="1726" alt="image" src="https://github.com/user-attachments/assets/c32c81f1-d1ab-4768-b0de-fda53e8467fc" />

