### PR TITLE
TC1 Clicked Events Weights Integration

### DIFF
--- a/client/src/components/events-components/EventModify.tsx
+++ b/client/src/components/events-components/EventModify.tsx
@@ -120,7 +120,7 @@ const EventModify = ({
           selected={date}
           onSelect={setDate}
           className="rounded-lg border bg-white"
-          disabled={(date) => date < new Date()}
+          disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
         />
         <Input
           type="time"

--- a/server/recommendations/locationService.js
+++ b/server/recommendations/locationService.js
@@ -26,8 +26,9 @@ const getGeoCode = async (location) => {
 };
 
 /*
+Gets nearby events and recommends them based on user characteristics
 Input: user id and user filters
-Output: List of nearby events sorted by most recommended -> least recommended
+Output: List of events
 */
 const getAllNearbyEvents = async (userId, userInputs) => {
   const user = await getNeededUserData(userId, userInputs);
@@ -76,6 +77,11 @@ const getEvents = async (filters, keys, userId) => {
   return events;
 };
 
+/*
+Gets the user data needed to retrieve nearby events
+Input: userId, userInputs
+Output: User object 
+*/
 const getNeededUserData = async (userId, userInputs) => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
@@ -105,6 +111,11 @@ const getNeededUserData = async (userId, userInputs) => {
   return user;
 };
 
+/*
+Creates a filter object that is used for the event db query
+Input: User inputs
+Output: Filter object
+*/
 const _getEventsFilters = (userInputs) => {
   const filters = {};
   if (userInputs.date && userInputs.date !== "undefined") {
@@ -123,6 +134,11 @@ const _getEventsFilters = (userInputs) => {
   return filters;
 };
 
+/*
+Calculates the keys need for searching events by location
+Input: User, User inputs
+Output: 2D Array of keys
+*/
 const _getEventKeys = (user, userInputs) => {
   const baseKey = {
     latitudeKey: user.latitudeKey,

--- a/server/recommendations/rankEvents.js
+++ b/server/recommendations/rankEvents.js
@@ -62,7 +62,7 @@ const getBounds = (events, preferenceMaps) => {
 /*
 Gets an event weight for an event where the higher the weight is, 
 the higher the event should be recommended.
-Input: Takes event, user date, and user's sports preferences
+Input: Takes event, user date, and preference maps
 Ouput: A weight for the event
 */
 const getEventWeight = (event, bounds, preferenceMaps) => {
@@ -102,6 +102,9 @@ const getEventWeight = (event, bounds, preferenceMaps) => {
   );
 };
 
+/*
+Gets the distance value for a given distance
+*/
 const _getDistanceValue = (distance, userDistanceMap) => {
   const index = DISTANCE_RANGES.findIndex(
     (currDistance) => distance <= currDistance

--- a/server/recommendations/rankEvents.js
+++ b/server/recommendations/rankEvents.js
@@ -1,3 +1,4 @@
+const { DISTANCE_RANGES } = require("../config");
 const { performHaversine } = require("./locationUtils");
 /*
 Takes in a list of nearby events to the user and ranks them based on user preferences
@@ -34,6 +35,8 @@ Calculates the bounds of a series of variables for normalization
 const getBounds = (events, preferenceMaps) => {
   const sportMap = preferenceMaps.userSportsMap;
   const userTimesMap = preferenceMaps.userTimesMap;
+  const userDistanceMap = preferenceMaps.userDistanceMap;
+
   const minDistance = Math.min(...events.map((event) => event.distance));
   const maxDistance = Math.max(...events.map((event) => event.distance));
   const minDate = Math.min(...events.map((event) => new Date(event.eventTime)));
@@ -42,6 +45,7 @@ const getBounds = (events, preferenceMaps) => {
   const distanceRange = maxDistance - minDistance;
   const dateRange = maxDate - minDate;
   const maxTimeValue = Math.max(...userTimesMap.values());
+  const maxDistanceValue = Math.max(...userDistanceMap.values());
   return {
     maxSportValue: maxSportValue > 0 ? maxSportValue : 1,
     minDistance,
@@ -51,6 +55,7 @@ const getBounds = (events, preferenceMaps) => {
     distanceRange,
     dateRange,
     maxTimeValue: maxTimeValue > 0 ? maxTimeValue : 1,
+    maxDistanceValue: maxDistanceValue > 0 ? maxDistanceValue : 1,
   };
 };
 
@@ -63,7 +68,9 @@ Ouput: A weight for the event
 const getEventWeight = (event, bounds, preferenceMaps) => {
   const sportsMap = preferenceMaps.userSportsMap;
   const userTimesMap = preferenceMaps.userTimesMap;
-  const LOCATION_WEIGHT = 0.5; // 50%
+  const userDistanceMap = preferenceMaps.userDistanceMap;
+  const LOCATION_WEIGHT = 0.45; // 45%
+  const DISTANCE_WEIGHT = 0.05; // 5%
   const DATE_WEIGHT = 0.25; // 25%
   const SPORT_WEIGHT = 0.15; // 15%
   const TIME_OF_DAY_WEIGHT = 0.1; // 10%
@@ -72,7 +79,7 @@ const getEventWeight = (event, bounds, preferenceMaps) => {
     : 0;
   const sportWeight =
     1 - (bounds.maxSportValue - sportValue) / bounds.maxSportValue;
-  const distanceWeight =
+  const locationWeight =
     1 - (event.distance - bounds.minDistance) / bounds.distanceRange;
   const dateWeight =
     1 - (new Date(event.eventTime) - bounds.minDate) / bounds.dateRange;
@@ -83,12 +90,27 @@ const getEventWeight = (event, bounds, preferenceMaps) => {
   const timeValue = userTimesMap.get(hour) ? userTimesMap.get(hour) : 0;
   const timeWeight =
     1 - (bounds.maxTimeValue - timeValue) / bounds.maxTimeValue;
+  const distanceValue = _getDistanceValue(event.distance, userDistanceMap);
+  const distanceWeight =
+    1 - (bounds.maxDistanceValue - distanceValue) / bounds.maxDistanceValue;
   return (
     sportWeight * SPORT_WEIGHT +
-    distanceWeight * LOCATION_WEIGHT +
+    locationWeight * LOCATION_WEIGHT +
     dateWeight * DATE_WEIGHT +
-    timeWeight * TIME_OF_DAY_WEIGHT
+    timeWeight * TIME_OF_DAY_WEIGHT +
+    distanceWeight * DISTANCE_WEIGHT
   );
+};
+
+const _getDistanceValue = (distance, userDistanceMap) => {
+  const index = DISTANCE_RANGES.findIndex(
+    (currDistance) => distance <= currDistance
+  );
+  if (index === -1) {
+    return 0;
+  }
+  const value = userDistanceMap.get(DISTANCE_RANGES[index]);
+  return value ? value : 0;
 };
 
 module.exports = { rankEvents };

--- a/server/services/eventService.js
+++ b/server/services/eventService.js
@@ -79,6 +79,9 @@ exports.getAllEventRSVP = async (userId) => {
         },
       },
     },
+    orderBy: {
+      updated_at: "desc",
+    },
   });
   const eventArr = rsvps.map((rsvp) => rsvp.event);
   return eventArr;


### PR DESCRIPTION
**Description**
This PR completes main logic behind technical challenge 1. It integrates the users clicked events data into the current implementation of calculating the event weights. For example, the clicked sports, profile sports, and rsvp'd sports are now taken into account when giving an event a weight.

In future PRs, more robustness and feedback from my team will be added.

**Milestones**
This works towards TC1.

**Resources**
N/A

**Test Plan**
To test, I printed out the value maps that are used to calculate an event's weight.
The image below shows the distance map created for calculations. The key is the distance range (1: [0,1], 3: [1,3], etc.). The value is the number of events that the user has clicked on with a distance that falls in that range. This works as intended. Furthermore, the values below the map shows calculated weights normalized on a scale from 0-1.
<img width="1360" height="748" alt="image" src="https://github.com/user-attachments/assets/49d22487-7899-427b-a433-47bf45dbd643" />

