### PR TITLE
TC1 Dynamic Weight Integration

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -56,7 +56,7 @@ const MAX_TIME_OF_DAY_WEIGHT = 0.15;
 // Ensures fairness in the algorithm for extreme cases
 const MAX_DATE_AND_SPORT_WEIGHT = 0.6;
 // Max weight change per click
-const MAX_CHANGE_PER_CLICK = 0.1;
+const MAX_CHANGE_PER_CLICK = 0.2;
 
 module.exports = {
   GOOGLE_MAPS_RADIUS,

--- a/server/config.js
+++ b/server/config.js
@@ -57,6 +57,12 @@ const MAX_TIME_OF_DAY_WEIGHT = 0.15;
 const MAX_DATE_AND_SPORT_WEIGHT = 0.6;
 // Max weight change per click
 const MAX_CHANGE_PER_CLICK = 0.2;
+// Sets the max count a feature can have so that a users click
+// will still impact the weights when a lot of
+// data is present
+const MAX_FEATURE_COUNT = 50;
+// Shinks the features counts proportionally when one hits the max feature count
+const SHRINK_MULTIPLIER_ON_MAX = 0.8; // 20% shrink
 
 module.exports = {
   GOOGLE_MAPS_RADIUS,
@@ -69,4 +75,6 @@ module.exports = {
   MAX_DATE_AND_SPORT_WEIGHT,
   MAX_TIME_OF_DAY_WEIGHT,
   MAX_CHANGE_PER_CLICK,
+  MAX_FEATURE_COUNT,
+  SHRINK_MULTIPLIER_ON_MAX,
 };

--- a/server/config.js
+++ b/server/config.js
@@ -49,9 +49,6 @@ calculation in the event recommendation algorithm
 // Used to calculate the likely hood an event was cliked on
 // because it is near in the future
 const MAX_DAYS_AWAY = 7;
-// Ensures the date field does not have a disproportional
-// effect on the weights
-const DATE_BALANCE = 1 / 3;
 // Max weight for the time of day.
 // Less important weight to the algorithm, so it gets capped.
 const MAX_TIME_OF_DAY_WEIGHT = 0.15;
@@ -71,6 +68,5 @@ module.exports = {
   MAX_DAYS_AWAY,
   MAX_DATE_AND_SPORT_WEIGHT,
   MAX_TIME_OF_DAY_WEIGHT,
-  DATE_BALANCE,
   MAX_CHANGE_PER_CLICK,
 };

--- a/server/recommendations/eventWeights.js
+++ b/server/recommendations/eventWeights.js
@@ -157,4 +157,11 @@ const updateRecommendationData = async (userId, newData) => {
   });
   return result;
 };
+
+const refreshRecommendationData = async (userId) => {
+  const result = await prisma.recommendationData.delete({
+    where: { userId: userId },
+  });
+  return result;
+};
 module.exports = { handleWeightChange };

--- a/server/recommendations/eventWeights.js
+++ b/server/recommendations/eventWeights.js
@@ -159,7 +159,6 @@ const updateRecommendationData = async (userId, newData) => {
     where: { userId: userId },
     data: newData,
   });
-  console.log(result);
   return result;
 };
 

--- a/server/recommendations/eventWeights.js
+++ b/server/recommendations/eventWeights.js
@@ -2,7 +2,6 @@ const {
   MILLISECS_TO_DAYS,
   MAX_TIME_OF_DAY_WEIGHT,
   MAX_DATE_AND_SPORT_WEIGHT,
-  DATE_BALANCE,
   MAX_DAYS_AWAY,
   MAX_CHANGE_PER_CLICK,
 } = require("../config.js");
@@ -97,8 +96,7 @@ const handleWeightChange = async (click) => {
     dateWeight: normalized.dateWeight,
     timeOfDayWeight: normalized.timeOfDayWeight,
   };
-  // updateRecommendationData(click.userId, updatedRecommendationData);
-  // refreshRecommendationData(click.userId);
+  updateRecommendationData(click.userId, updatedRecommendationData);
 };
 
 /* Normalizes the weights */
@@ -161,6 +159,7 @@ const updateRecommendationData = async (userId, newData) => {
     where: { userId: userId },
     data: newData,
   });
+  console.log(result);
   return result;
 };
 

--- a/server/recommendations/eventWeights.js
+++ b/server/recommendations/eventWeights.js
@@ -48,11 +48,16 @@ const handleWeightChange = async (click) => {
     (sum, sport) => sum + sport,
     0
   );
+  const maxSport = Object.values(sportBuckets).reduce(
+    (max, sport) => Math.max(max, sport),
+    0
+  );
+  const dateBalance = maxSport / totalSport;
 
   const sportAddition = sportBuckets[click.event.sport] / totalSport;
   const timeOfDayAddition = timeOfDayBuckets[timeOfDayBucket] / totalTimeOfDay;
   const dateAddition =
-    Math.max((MAX_DAYS_AWAY - dateDiff) / MAX_DAYS_AWAY, 0) * DATE_BALANCE;
+    Math.max((MAX_DAYS_AWAY - dateDiff) / MAX_DAYS_AWAY, 0) * dateBalance;
 
   const newCounts = {
     timeOfDayCount: counts.timeOfDayCount + timeOfDayAddition,
@@ -92,7 +97,8 @@ const handleWeightChange = async (click) => {
     dateWeight: normalized.dateWeight,
     timeOfDayWeight: normalized.timeOfDayWeight,
   };
-  updateRecommendationData(click.userId, updatedRecommendationData);
+  // updateRecommendationData(click.userId, updatedRecommendationData);
+  // refreshRecommendationData(click.userId);
 };
 
 /* Normalizes the weights */

--- a/server/recommendations/locationService.js
+++ b/server/recommendations/locationService.js
@@ -62,7 +62,12 @@ const getAllNearbyEvents = async (userId, userInputs) => {
     preparedEvents,
     { latitude: user.latitude, longitude: user.longitude },
     { userSportsMap, userTimesMap, userDistanceMap },
-    userInputs.radius
+    userInputs.radius,
+    {
+      dateWeight: user.recommendationData.dateWeight,
+      sportWeight: user.recommendationData.sportWeight,
+      timeOfDayWeight: user.recommendationData.timeOfDayWeight,
+    }
   );
   return rankedEvents;
 };
@@ -129,6 +134,13 @@ const getNeededUserData = async (userId, userInputs) => {
               eventTime: true,
             },
           },
+        },
+      },
+      recommendationData: {
+        select: {
+          timeOfDayWeight: true,
+          sportWeight: true,
+          dateWeight: true,
         },
       },
     },

--- a/server/recommendations/locationService.js
+++ b/server/recommendations/locationService.js
@@ -64,9 +64,9 @@ const getAllNearbyEvents = async (userId, userInputs) => {
     { userSportsMap, userTimesMap, userDistanceMap },
     userInputs.radius,
     {
-      dateWeight: user.recommendationData.dateWeight,
-      sportWeight: user.recommendationData.sportWeight,
-      timeOfDayWeight: user.recommendationData.timeOfDayWeight,
+      dateWeight: user.recommendationData?.dateWeight,
+      sportWeight: user.recommendationData?.sportWeight,
+      timeOfDayWeight: user.recommendationData?.timeOfDayWeight,
     }
   );
   return rankedEvents;

--- a/server/recommendations/rankEvents.js
+++ b/server/recommendations/rankEvents.js
@@ -98,11 +98,14 @@ const getEventWeight = (event, bounds, preferenceMaps, dynamicWeights) => {
   const WEATHER_WEIGHT = 0.05; // 5%
   const DYNAMIC_WEIGHT_PERCENTAGE = 0.45; //45%
   const dynamicSportWeight =
-    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.sportWeight;
+    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.sportWeight ||
+    DYNAMIC_WEIGHT_PERCENTAGE * 0.35;
   const dynamicDateWeight =
-    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.dateWeight;
+    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.dateWeight ||
+    DYNAMIC_WEIGHT_PERCENTAGE * 0.5;
   const dynamicTimeOfDayWeight =
-    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.timeOfDayWeight;
+    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.timeOfDayWeight ||
+    DYNAMIC_WEIGHT_PERCENTAGE * 0.15;
   const sportValue = sportsMap.get(event.sport)
     ? sportsMap.get(event.sport)
     : 0;

--- a/server/recommendations/rankEvents.js
+++ b/server/recommendations/rankEvents.js
@@ -99,13 +99,13 @@ const getEventWeight = (event, bounds, preferenceMaps, dynamicWeights) => {
   const DYNAMIC_WEIGHT_PERCENTAGE = 0.45; //45%
   const dynamicSportWeight =
     DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.sportWeight ||
-    DYNAMIC_WEIGHT_PERCENTAGE * 0.35;
+    DYNAMIC_WEIGHT_PERCENTAGE * 0.35; // 35% default of dynamic weight
   const dynamicDateWeight =
     DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.dateWeight ||
-    DYNAMIC_WEIGHT_PERCENTAGE * 0.5;
+    DYNAMIC_WEIGHT_PERCENTAGE * 0.5; // 50% default of dynamic weight
   const dynamicTimeOfDayWeight =
     DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.timeOfDayWeight ||
-    DYNAMIC_WEIGHT_PERCENTAGE * 0.15;
+    DYNAMIC_WEIGHT_PERCENTAGE * 0.15; // 15% default of dynamic weight
   const sportValue = sportsMap.get(event.sport)
     ? sportsMap.get(event.sport)
     : 0;

--- a/server/recommendations/rankEvents.js
+++ b/server/recommendations/rankEvents.js
@@ -8,7 +8,13 @@ const { performHaversine } = require("./locationUtils");
  * @param {Object} preferenceMaps - Object with preference Maps
  * @returns {Event[]} - Ranked events
  */
-const rankEvents = (events, userLocation, preferenceMaps, radius) => {
+const rankEvents = (
+  events,
+  userLocation,
+  preferenceMaps,
+  radius,
+  dynamicWeights
+) => {
   const eventsWithDistance = events.map((event) => {
     event.distance =
       Math.round(
@@ -27,7 +33,12 @@ const rankEvents = (events, userLocation, preferenceMaps, radius) => {
   );
   const bounds = getBounds(filterFarEvents, preferenceMaps);
   const eventsWithWeights = filterFarEvents.map((event) => {
-    event.weight = getEventWeight(event, bounds, preferenceMaps);
+    event.weight = getEventWeight(
+      event,
+      bounds,
+      preferenceMaps,
+      dynamicWeights
+    );
     return event;
   });
   const rankedEvents = eventsWithWeights.toSorted((a, b) =>
@@ -78,16 +89,20 @@ const getBounds = (events, preferenceMaps) => {
  * @param {Object} preferenceMaps - Object with preference Maps
  * @returns {number} - Resulting weight for the object
  */
-const getEventWeight = (event, bounds, preferenceMaps) => {
+const getEventWeight = (event, bounds, preferenceMaps, dynamicWeights) => {
   const sportsMap = preferenceMaps.userSportsMap;
   const userTimesMap = preferenceMaps.userTimesMap;
   const userDistanceMap = preferenceMaps.userDistanceMap;
   const LOCATION_WEIGHT = 0.45; // 45%
   const DISTANCE_WEIGHT = 0.05; // 5%
-  const DATE_WEIGHT = 0.22; // 22%
-  const SPORT_WEIGHT = 0.13; // 13%
-  const TIME_OF_DAY_WEIGHT = 0.1; // 10%
   const WEATHER_WEIGHT = 0.05; // 5%
+  const DYNAMIC_WEIGHT_PERCENTAGE = 0.45; //45%
+  const dynamicSportWeight =
+    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.sportWeight;
+  const dynamicDateWeight =
+    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.dateWeight;
+  const dynamicTimeOfDayWeight =
+    DYNAMIC_WEIGHT_PERCENTAGE * dynamicWeights.timeOfDayWeight;
   const sportValue = sportsMap.get(event.sport)
     ? sportsMap.get(event.sport)
     : 0;
@@ -109,10 +124,10 @@ const getEventWeight = (event, bounds, preferenceMaps) => {
     1 - (bounds.maxDistanceValue - distanceValue) / bounds.maxDistanceValue;
   const weatherWeight = _getWeatherValue(event.weather);
   return (
-    sportWeight * SPORT_WEIGHT +
+    sportWeight * dynamicSportWeight +
     locationWeight * LOCATION_WEIGHT +
-    dateWeight * DATE_WEIGHT +
-    timeWeight * TIME_OF_DAY_WEIGHT +
+    dateWeight * dynamicDateWeight +
+    timeWeight * dynamicTimeOfDayWeight +
     distanceWeight * DISTANCE_WEIGHT +
     weatherWeight * WEATHER_WEIGHT
   );


### PR DESCRIPTION
**Description**
This PR incorporates the dynamic weights from the last PR into the main recommendation algorithm. It also promotes fairness by changing the way the sport preference is calculated. It divides the sport count clicked by the max sport clicks in the sportBuckets instead of by the total clicks for all sports so that a click on a sport can grow as fast as a click on an event in the near future. It also sets a max count that an event can have so that as the user clicks on more and more events, the weights will stay volatile.

**Milestones**
This works towards TC1.

**Resources**
N/A

**Test Plan**
To test, I printed out the weights in the terminal to make sure that everything was changing as expected. I also started fresh with a new user to make sure that there was not initialization edge cases I missed. The image shows the weights changing on different clicks.
<img width="982" height="1498" alt="image" src="https://github.com/user-attachments/assets/62c7d89e-56ae-49fd-b96e-590e3d8cfab5" />